### PR TITLE
[#65] 인증/인가 활성화 및 @LoginMember 적용

### DIFF
--- a/src/main/java/com/climingo/climingoApi/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/climingo/climingoApi/global/auth/JwtAuthenticationFilter.java
@@ -45,6 +45,11 @@ public class JwtAuthenticationFilter extends BasicAuthenticationFilter {
             authentication = authenticateWithRefreshToken(request, response);
         }
 
+        if (!authentication.isAuthenticated()) {
+            SecurityContextHolder.clearContext();
+            return;
+        }
+
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 

--- a/src/main/java/com/climingo/climingoApi/global/auth/LoginMemberArgumentResolver.java
+++ b/src/main/java/com/climingo/climingoApi/global/auth/LoginMemberArgumentResolver.java
@@ -48,7 +48,7 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
         }
 
         Optional<Cookie> refreshTokenCookie = CookieUtils.getCookie(request, JwtUtil.REFRESH_TOKEN_NAME);
-        token = refreshTokenCookie.orElseThrow(AuthenticationException::new).getValue();
+        token = refreshTokenCookie.orElseThrow(() -> new AuthenticationException("로그인을 다시 진행해주세요")).getValue();
         authId = JwtUtil.getAuthId(token);
         providerType = JwtUtil.getProviderType(token);
 

--- a/src/main/java/com/climingo/climingoApi/global/config/SecurityConfig.java
+++ b/src/main/java/com/climingo/climingoApi/global/config/SecurityConfig.java
@@ -44,17 +44,12 @@ public class SecurityConfig {
             .headers((headerConfig) -> headerConfig.frameOptions(FrameOptionsConfig::disable))
             .authenticationManager(authenticationManager)
             .authorizeHttpRequests((authorizeRequests ->
-                    // TODO 어떤 API에 인증/인가 처리를 둘 것인지 논의 필요
                     authorizeRequests
                         .requestMatchers(PathRequest.toH2Console()).permitAll()
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/**").permitAll() // TODO 프론트 쪽 로그인 테스트 후 변경 예정
-                        .requestMatchers(HttpMethod.POST, "/**").permitAll() // TODO 프론트 쪽 로그인 테스트 후 변경 예정
-                        .requestMatchers(HttpMethod.PATCH, "/**").permitAll() // TODO 프론트 쪽 로그인 테스트 후 변경 예정
-                        .requestMatchers(HttpMethod.PUT, "/**").permitAll() // TODO 프론트 쪽 로그인 테스트 후 변경 예정
-                        .requestMatchers(HttpMethod.DELETE, "/**").permitAll() // TODO 프론트 쪽 로그인 테스트 후 변경 예정
-//                        .requestMatchers("/healthCheck", "/sign-up", "/sign-in", "/auth/members/exist")
-//                        .permitAll()
+                        .requestMatchers(HttpMethod.GET, "/members", "/auth/members/exist").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/**").permitAll()
+                        .requestMatchers("/healthCheck", "/sign-up", "/sign-in").permitAll()
                         .anyRequest().authenticated()
                 )
             )

--- a/src/main/java/com/climingo/climingoApi/global/exception/ForbiddenException.java
+++ b/src/main/java/com/climingo/climingoApi/global/exception/ForbiddenException.java
@@ -1,0 +1,8 @@
+package com.climingo.climingoApi.global.exception;
+
+public class ForbiddenException extends RuntimeException {
+
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/climingo/climingoApi/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/climingo/climingoApi/global/exception/GlobalExceptionHandler.java
@@ -75,8 +75,8 @@ public class GlobalExceptionHandler {
     }
 
     @ResponseStatus(HttpStatus.FORBIDDEN)
-    @ExceptionHandler(AccessDeniedException.class)
-    public ExceptionResponse handleAccessDeniedException(AccessDeniedException e) {
+    @ExceptionHandler(value = {AccessDeniedException.class, ForbiddenException.class})
+    public ExceptionResponse handleAccessDeniedException(RuntimeException e) {
         return ExceptionResponse.of(HttpStatus.FORBIDDEN.getReasonPhrase(), e.getMessage());
     }
 

--- a/src/main/java/com/climingo/climingoApi/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/climingo/climingoApi/global/exception/GlobalExceptionHandler.java
@@ -1,9 +1,11 @@
 package com.climingo.climingoApi.global.exception;
 
 import com.climingo.climingoApi.message.error.ErrorAlertMessageProvider;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import java.util.NoSuchElementException;
+import javax.naming.AuthenticationException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -25,16 +27,23 @@ public class GlobalExceptionHandler {
     private final ErrorAlertMessageProvider messageProvider;
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @ExceptionHandler({NoSuchElementException.class, IllegalArgumentException.class})
+    @ExceptionHandler({IllegalArgumentException.class})
     public ExceptionResponse badRequestExceptionHandler(Exception e) {
-        log.error("[error]", e);
+        log.error("[BAD_REQUEST]", e);
         return ExceptionResponse.of(HttpStatus.BAD_REQUEST.getReasonPhrase(), e.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ExceptionHandler({AuthenticationException.class})
+    public ExceptionResponse unAuthorizedExceptionHandler(AuthenticationException e) {
+        log.error("[BAD_REQUEST]", e);
+        return ExceptionResponse.of(HttpStatus.UNAUTHORIZED.getReasonPhrase(), e.getMessage());
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ExceptionResponse validationExceptionHandler(MethodArgumentNotValidException e) {
-        log.error("[error]", e);
+        log.error("[BAD_REQUEST]", e);
         return ExceptionResponse.of(HttpStatus.BAD_REQUEST.getReasonPhrase(), e.getMessage(), e.getBindingResult());
     }
 
@@ -48,8 +57,15 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(ConstraintViolationException.class)
     public ExceptionResponse constraintViolationExceptionHandler(ConstraintViolationException e) {
-        log.error("[error]", e);
+        log.error("[BAD_REQUEST]", e);
         return ExceptionResponse.of(HttpStatus.BAD_REQUEST.getReasonPhrase(), e.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler({NoSuchElementException.class, EntityNotFoundException.class})
+    public ExceptionResponse notFoundExceptionHandler(Exception e) {
+        log.error("[NOT_FOUND]", e);
+        return ExceptionResponse.of(HttpStatus.NOT_FOUND.getReasonPhrase(), e.getMessage());
     }
 
     @ResponseStatus(HttpStatus.CONFLICT)

--- a/src/main/java/com/climingo/climingoApi/member/api/MemberController.java
+++ b/src/main/java/com/climingo/climingoApi/member/api/MemberController.java
@@ -22,8 +22,8 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping("/members")
-    public ResponseEntity<ProfileResponse> findMyInfo() {
-        ProfileResponse profileResponse = memberService.findMyInfo(1L);
+    public ResponseEntity<ProfileResponse> findMyInfo(@LoginMember Member loginMember) {
+        ProfileResponse profileResponse = memberService.findMyInfo(loginMember.getId());
         return ResponseEntity.ok().body(profileResponse);
     }
 

--- a/src/main/java/com/climingo/climingoApi/member/application/MemberServiceImpl.java
+++ b/src/main/java/com/climingo/climingoApi/member/application/MemberServiceImpl.java
@@ -72,10 +72,10 @@ public class MemberServiceImpl implements SignUpService, SignInService, MemberSe
     }
 
     @Override
-
     @Transactional(readOnly = true)
     public ProfileResponse findMyInfo(Long memberId) {
-        Member member = memberRepository.findMemberWithRecords(memberId);
+        Member member = memberRepository.findByIdWithRecords(memberId)
+            .orElseThrow(() -> new EntityNotFoundException("id가 " + memberId + "인 회원은 존재하지 않습니다"));
 
         List<RecordResponse> recordResponses = new ArrayList<>();
         for (Record record : member.getRecords()) {
@@ -93,7 +93,7 @@ public class MemberServiceImpl implements SignUpService, SignInService, MemberSe
     @Transactional(readOnly = true)
     public MemberInfoResponse findMemberInfo(Long memberId) {
         Member member = memberRepository.findById(memberId)
-            .orElseThrow(() -> new EntityNotFoundException(memberId + "is not found"));
+            .orElseThrow(() -> new EntityNotFoundException("id가 " + memberId + "인 회원은 존재하지 않습니다"));
 
         return new MemberInfoResponse(member);
     }

--- a/src/main/java/com/climingo/climingoApi/member/domain/MemberRepository.java
+++ b/src/main/java/com/climingo/climingoApi/member/domain/MemberRepository.java
@@ -15,6 +15,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByAuthIdAndProviderType(String authId, String providerType);
 
-    @Query("SELECT m FROM Member m JOIN FETCH m.records WHERE m.id = :memberId")
-    Member findMemberWithRecords(@Param("memberId") Long memberId);
+    @Query("SELECT m FROM Member m LEFT JOIN FETCH m.records WHERE m.id = :memberId")
+    Optional<Member> findByIdWithRecords(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/climingo/climingoApi/record/api/RecordController.java
+++ b/src/main/java/com/climingo/climingoApi/record/api/RecordController.java
@@ -1,5 +1,7 @@
 package com.climingo.climingoApi.record.api;
 
+import com.climingo.climingoApi.global.auth.LoginMember;
+import com.climingo.climingoApi.member.domain.Member;
 import com.climingo.climingoApi.record.api.request.RecordCreateRequest;
 import com.climingo.climingoApi.record.api.request.RecordUpdateRequest;
 import com.climingo.climingoApi.record.api.response.PageDto;
@@ -8,7 +10,6 @@ import com.climingo.climingoApi.record.application.RecordService;
 import com.climingo.climingoApi.record.domain.Record;
 import jakarta.validation.constraints.Min;
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -28,21 +29,29 @@ public class RecordController {
     private final RecordService recordService;
 
     @PostMapping("/records")
-    public ResponseEntity<Map<String,Long>> create(@ModelAttribute RecordCreateRequest request)
-            throws IOException, InterruptedException {
-        Record record = recordService.createRecord(request);
+    public ResponseEntity<Map<String, Long>> create(
+        @LoginMember Member loginMember,
+        @ModelAttribute RecordCreateRequest request) throws IOException {
+
+        Record record = recordService.createRecord(loginMember, request);
         return ResponseEntity.ok().body(Map.of("recordId", record.getId()));
     }
 
     @PatchMapping("/records/{recordId}")
-    public ResponseEntity<Long> update(@PathVariable("recordId") Long recordId, @ModelAttribute RecordUpdateRequest request) {
-        Record record = recordService.updateRecord(recordId, request);
+    public ResponseEntity<Long> update(
+        @LoginMember Member loginMember,
+        @PathVariable("recordId") Long recordId,
+        @ModelAttribute RecordUpdateRequest request) {
+
+        Record record = recordService.updateRecord(loginMember, recordId, request);
         return ResponseEntity.ok().body(record.getId());
     }
 
     @DeleteMapping("/records/{recordId}")
-    public ResponseEntity<Void> delete(@PathVariable("recordId") Long recordId) {
-        recordService.deleteRecord(recordId);
+    public ResponseEntity<Void> delete(
+        @LoginMember Member loginMember,
+        @PathVariable("recordId") Long recordId) {
+        recordService.deleteRecord(loginMember, recordId);
         return ResponseEntity.ok(null);
     }
 

--- a/src/main/java/com/climingo/climingoApi/record/domain/Record.java
+++ b/src/main/java/com/climingo/climingoApi/record/domain/Record.java
@@ -11,13 +11,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.experimental.SuperBuilder;
 
 @Setter
 @Getter
@@ -70,4 +68,7 @@ public class Record extends BaseTimeEntity {
         // TODO: origin 영상 데이터와 updated 영상 데이터가 다른걸 어떻게 알 것인가?
     }
 
+    public boolean isSameMember(Member member) {
+        return this.member.isSameMember(member.getId());
+    }
 }

--- a/src/test/java/com/climingo/climingoApi/record/application/RecordServiceTest.java
+++ b/src/test/java/com/climingo/climingoApi/record/application/RecordServiceTest.java
@@ -1,0 +1,229 @@
+package com.climingo.climingoApi.record.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.climingo.climingoApi.global.exception.ForbiddenException;
+import com.climingo.climingoApi.gym.domain.Gym;
+import com.climingo.climingoApi.gym.domain.GymRepository;
+import com.climingo.climingoApi.level.domain.Level;
+import com.climingo.climingoApi.level.domain.LevelRepository;
+import com.climingo.climingoApi.member.domain.Member;
+import com.climingo.climingoApi.record.api.request.RecordCreateRequest;
+import com.climingo.climingoApi.record.api.request.RecordUpdateRequest;
+import com.climingo.climingoApi.record.domain.Record;
+import com.climingo.climingoApi.record.domain.RecordRepository;
+import com.climingo.climingoApi.upload.S3Service;
+import com.climingo.climingoApi.upload.ThumbnailExtractor;
+import java.io.File;
+import java.io.IOException;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.multipart.MultipartFile;
+
+@DisplayName("RecordService Unit Tests")
+public class RecordServiceTest {
+
+    private RecordService recordService;
+
+    private RecordRepository recordRepository;
+    private GymRepository gymRepository;
+    private LevelRepository levelRepository;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        S3Service s3Service = mock(S3Service.class);
+        ThumbnailExtractor thumbnailExtractor = mock(ThumbnailExtractor.class);
+        gymRepository = mock(GymRepository.class);
+        levelRepository = mock(LevelRepository.class);
+        recordRepository = mock(RecordRepository.class);
+
+        when(s3Service.uploadVideoFile(any())).thenReturn("http://mock-video-url");
+        when(s3Service.uploadImageFile(any())).thenReturn("http://mock-thumbnail-url");
+        when(thumbnailExtractor.extractImage(any())).thenReturn(mock(File.class));
+
+        recordService = new RecordService(
+            s3Service, thumbnailExtractor, gymRepository, levelRepository, recordRepository);
+    }
+
+    @Test
+    @DisplayName("기록 생성 테스트 - 정상적인 요청의 경우 로그인한 사용자가 작성자인 기록이 생성된다.")
+    void create_test() throws IOException {
+        Long mockGymId = 1L;
+        Long mockLevelId = 1L;
+        MultipartFile mockVideo = mock(MultipartFile.class);
+
+        Member loginMember = Member.builder()
+            .id(99999L)
+            .build();
+        RecordCreateRequest request = new RecordCreateRequest(mockGymId, mockLevelId, mockVideo);
+
+        Record expected = Record.builder()
+            .member(loginMember)
+            .videoUrl("http://mock-video-url")
+            .thumbnailUrl("http://mock-thumbnail-url")
+            .build();
+
+        when(gymRepository.findById(anyLong())).thenReturn(Optional.of(mock(Gym.class)));
+        when(levelRepository.findById(anyLong())).thenReturn(Optional.of(mock(Level.class)));
+        when(recordRepository.save(any())).thenReturn(expected);
+
+        Record actual = recordService.createRecord(loginMember, request);
+
+        assertEquals(expected.getMember(), actual.getMember());
+        assertEquals(expected.getVideoUrl(), actual.getVideoUrl());
+        assertEquals(expected.getThumbnailUrl(), actual.getThumbnailUrl());
+    }
+
+    @Test
+    @DisplayName("기록 수정 테스트 - 로그인한 사용자와 수정하려는 기록의 작성자가 동일한 경우 정상적으로 수정된다.")
+    void update_test() {
+        Member loginMember = Member.builder()
+            .id(99999L)
+            .build();
+
+        Gym gym1 = mock(Gym.class);
+        when(gym1.getId()).thenReturn(1L);
+
+        Gym gym2 = mock(Gym.class);
+        when(gym2.getId()).thenReturn(2L);
+
+        Level level1 = mock(Level.class);
+        when(level1.getId()).thenReturn(1L);
+
+        Level level2 = mock(Level.class);
+        when(level2.getId()).thenReturn(2L);
+
+        Record before = Record.builder()
+            .member(loginMember)
+            .gym(gym1)
+            .level(level1)
+            .videoUrl("http://mock-video-url")
+            .thumbnailUrl("http://mock-thumbnail-url")
+            .build();
+
+        Record expected = Record.builder()
+            .member(loginMember)
+            .gym(gym2)
+            .level(level2)
+            .videoUrl("http://mock-video-url")
+            .thumbnailUrl("http://mock-thumbnail-url")
+            .build();
+
+        when(gymRepository.findById(1L)).thenReturn(Optional.of(gym1));
+        when(levelRepository.findById(1L)).thenReturn(Optional.of(level1));
+        when(gymRepository.findById(2L)).thenReturn(Optional.of(gym2));
+        when(levelRepository.findById(2L)).thenReturn(Optional.of(level2));
+        when(recordRepository.findById(1L)).thenReturn(Optional.of(before));
+        when(recordRepository.save(any())).thenReturn(expected);
+
+        Long updatedGymId = 2L;
+        Long updatedLevelId = 2L;
+        MultipartFile mockVideo = mock(MultipartFile.class);
+
+        RecordUpdateRequest request = new RecordUpdateRequest(updatedGymId, updatedLevelId, mockVideo);
+        Record actual = recordService.updateRecord(loginMember, 1L, request);
+
+        assertEquals(expected.getMember(), actual.getMember());
+        assertEquals(2L, actual.getGym().getId());
+        assertEquals(2L, actual.getGym().getId());
+    }
+
+    @Test
+    @DisplayName("기록 수정 테스트 - 로그인한 사용자와 수정하려는 기록의 작성자 다른 경우 권한 제한(forbidden)예외가 발생한다.")
+    void update_test_when_not_same_member_then_throw_exception() {
+        Member loginMember = Member.builder()
+            .id(99999L)
+            .build();
+
+        Gym gym1 = mock(Gym.class);
+        when(gym1.getId()).thenReturn(1L);
+
+        Gym gym2 = mock(Gym.class);
+        when(gym2.getId()).thenReturn(2L);
+
+        Level level1 = mock(Level.class);
+        when(level1.getId()).thenReturn(1L);
+
+        Level level2 = mock(Level.class);
+        when(level2.getId()).thenReturn(2L);
+
+        Record before = Record.builder()
+            .member(Member.builder().id(100000L).build())
+            .gym(gym1)
+            .level(level1)
+            .videoUrl("http://mock-video-url")
+            .thumbnailUrl("http://mock-thumbnail-url")
+            .build();
+
+        when(gymRepository.findById(1L)).thenReturn(Optional.of(gym1));
+        when(levelRepository.findById(1L)).thenReturn(Optional.of(level1));
+        when(gymRepository.findById(2L)).thenReturn(Optional.of(gym2));
+        when(levelRepository.findById(2L)).thenReturn(Optional.of(level2));
+        when(recordRepository.findById(1L)).thenReturn(Optional.of(before));
+
+        Long updatedGymId = 2L;
+        Long updatedLevelId = 2L;
+        MultipartFile mockVideo = mock(MultipartFile.class);
+
+        RecordUpdateRequest request = new RecordUpdateRequest(updatedGymId, updatedLevelId, mockVideo);
+
+        Throwable exception = assertThrows(ForbiddenException.class,
+            () -> recordService.updateRecord(loginMember, 1L, request));
+        assertEquals("다른 사용자가 업로드한 record는 수정할 수 없음", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("기록 삭제 테스트 - 로그인한 사용자와 삭제하려는 기록의 작성자가 동일한 경우 정상적으로 삭제된다.")
+    void delete_test() {
+        Member loginMember = Member.builder()
+            .id(99999L)
+            .build();
+
+        Record before = Record.builder()
+            .member(loginMember)
+            .build();
+
+        when(recordRepository.findById(1L)).thenReturn(Optional.of(before));
+        doNothing().when(recordRepository).delete(any());
+
+        recordService.deleteRecord(loginMember, 1L);
+        when(recordRepository.findById(1L)).thenReturn(Optional.empty());
+
+        Throwable exception = assertThrows(NoSuchElementException.class,
+            () -> recordService.deleteRecord(loginMember, 1L));
+        assertEquals("존재하지 않는 기록입니다.", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("기록 삭제 테스트 - 로그인한 사용자와 삭제하려는 기록의 작성자 다른 경우 권한 제한(forbidden)예외가 발생한다.")
+    void delete_test_when_not_same_member_then_throw_exception() {
+        Member loginMember = Member.builder()
+            .id(99999L)
+            .build();
+
+        Record before = Record.builder()
+            .member(Member.builder().id(100000L).build())
+            .build();
+
+        when(recordRepository.findById(1L)).thenReturn(Optional.of(before));
+
+        Throwable exception = assertThrows(ForbiddenException.class,
+            () -> recordService.deleteRecord(loginMember, 1L));
+        assertEquals("다른 사용자가 업로드한 record는 삭제할 수 없음", exception.getMessage());
+    }
+
+    // TODO
+    @Test
+    @DisplayName("기록 조회 테스트 - ")
+    void read_test() {
+    }
+}


### PR DESCRIPTION
- 임시로 하드코딩되어있던 id 값을 로그인 회원의 id을 참조하도록 변경
- security authenticated 활성화
- 예외 메시지 및 핸들링 수정
- 내정보 조회 쿼리 수정 (left join 누락 부분)
- 기록 생성, 삭제, 수정에 대한 권한 로직 추가 및 테스트 코드 추가

close #65 