### PR TITLE
[#135] 401 응답 시, origin 관련 헤더 추가 안되는 이슈 해결

### DIFF
--- a/src/main/java/com/climingo/climingoApi/global/config/SecurityConfig.java
+++ b/src/main/java/com/climingo/climingoApi/global/config/SecurityConfig.java
@@ -5,6 +5,9 @@ import com.climingo.climingoApi.auth.application.AuthTokenService;
 import com.climingo.climingoApi.global.auth.JwtAuthenticationFilter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.PrintWriter;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
@@ -73,6 +76,7 @@ public class SecurityConfig {
                 "Spring security unauthorized...");
             response.setStatus(HttpStatus.UNAUTHORIZED.value());
             String json = new ObjectMapper().writeValueAsString(fail);
+            setCorsHeaders(request, response);
             response.setContentType(MediaType.APPLICATION_JSON_VALUE);
             response.setCharacterEncoding("UTF-8");
             PrintWriter writer = response.getWriter();
@@ -87,12 +91,18 @@ public class SecurityConfig {
                 "Spring security forbidden...");
             response.setStatus(HttpStatus.FORBIDDEN.value());
             String json = new ObjectMapper().writeValueAsString(fail);
+            setCorsHeaders(request, response);
             response.setContentType(MediaType.APPLICATION_JSON_VALUE);
             response.setCharacterEncoding("UTF-8");
             PrintWriter writer = response.getWriter();
             writer.write(json);
             writer.flush();
         };
+
+    private void setCorsHeaders(HttpServletRequest request, HttpServletResponse response) {
+        response.setHeader("Access-Control-Allow-Origin", request.getHeader("Origin"));
+        response.setHeader("Access-Control-Allow-Credentials", "true");
+    }
 
     public record ErrorResponse(HttpStatus status, String message) {
     }


### PR DESCRIPTION
401, 403 응답 시 origin 관련 헤더가 추가되지 않는 문제를 해결했습니다.

**원인**
- 401, 403의 경우 cors filter보다 별도의 security filter가 먼저 처리 후 반환하여 cors filter가 동작하지 않았음

**해결**
- security filter에서 401, 403을 처리하는 핸들러에서 헤더를 추가하도록 변경

cors filter 등록 부분과 코드가 중복되는 것이 있어 추후 개선 필요

close #135 